### PR TITLE
标志量需要volatile

### DIFF
--- a/src/main/java/org/beykery/jkcp/KcpThread.java
+++ b/src/main/java/org/beykery/jkcp/KcpThread.java
@@ -18,7 +18,7 @@ public class KcpThread extends Thread
 
   private final Output out;
   private final LinkedBlockingQueue<DatagramPacket> inputs;
-  private boolean running;
+  private volatile boolean running;
   private final Map<InetSocketAddress, KcpOnUdp> kcps;
   private final KcpListerner listerner;
   private int nodelay;


### PR DESCRIPTION
volatile可以避免多线程可见性问题。
